### PR TITLE
[feature] Video Owner

### DIFF
--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -1,6 +1,6 @@
 import { ForbiddenError, NotFoundError, ValidationError } from "../errors";
 import { avatarUpload } from "../middlewares/uploads";
-import { UserService, VideoService } from "../services";
+import { UserService } from "../services";
 import {
   arePasswordsEqual,
   isValidProfileData,
@@ -47,15 +47,13 @@ export const postUser = async (req, res, next) => {
 export const getProfile = async (req, res, next) => {
   const { id } = req.params;
   try {
-    const user = await UserService.getUserById(id);
+    const user = await UserService.getUserById(id).populate("videos");
     if (!user) {
       throw new NotFoundError("요청한 유저를 찾을 수 없습니다.");
     }
-    const videos = await VideoService.findAllByOwner(user._id);
     return res.render("profile", {
       pageTitle: user.name,
       user: user.toSafeObject(),
-      videos,
     });
   } catch (error) {
     next(error);

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -1,6 +1,6 @@
 import { ForbiddenError, NotFoundError, ValidationError } from "../errors";
 import { avatarUpload } from "../middlewares/uploads";
-import { UserService } from "../services";
+import { UserService, VideoService } from "../services";
 import {
   arePasswordsEqual,
   isValidProfileData,
@@ -51,9 +51,11 @@ export const getProfile = async (req, res, next) => {
     if (!user) {
       throw new NotFoundError("요청한 유저를 찾을 수 없습니다.");
     }
+    const videos = await VideoService.findAllByOwner(user._id);
     return res.render("profile", {
       pageTitle: user.name,
       user: user.toSafeObject(),
+      videos,
     });
   } catch (error) {
     next(error);

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -21,10 +21,9 @@ export const postUser = async (req, res, next) => {
     if (!arePasswordsEqual(password, password2)) {
       throw new ValidationError("비밀번호가 일치하지 않습니다.", "join");
     }
-    const user = await UserService.existsUser(
-      { $or: [{ username }, { email }] },
-      true
-    );
+    const user = await UserService.existsUser({
+      $or: [{ username }, { email }],
+    });
     if (user) {
       throw new ValidationError(
         "이미 존재하는 유저 이름 또는 이메일입니다.",
@@ -76,7 +75,7 @@ export const updateProfile = async (req, res, next) => {
     file,
   } = req;
   try {
-    if (id !== _id) {
+    if (String(id) !== String(_id)) {
       throw new ForbiddenError("해당 권한이 없습니다.", "edit-profile");
     }
 
@@ -87,12 +86,9 @@ export const updateProfile = async (req, res, next) => {
       );
     }
 
-    let user = await UserService.existsUser(
-      {
-        $and: [{ _id: { $ne: _id } }, { $or: [{ username }, { email }] }],
-      },
-      true
-    );
+    let user = await UserService.existsUser({
+      $and: [{ _id: { $ne: _id } }, { $or: [{ username }, { email }] }],
+    });
     if (user) {
       throw new ValidationError(
         "이미 존재하는 유저 이름 또는 이메일입니다.",

--- a/src/controllers/videoController.js
+++ b/src/controllers/videoController.js
@@ -1,6 +1,6 @@
 import { NotFoundError, ValidationError } from "../errors";
 import { videoUpload } from "../middlewares/uploads";
-import { UserService, VideoService } from "../services";
+import { VideoService } from "../services";
 import { isValidVideoData } from "../utils/validators";
 import { handleUpload } from "../utils/uploadHandler";
 
@@ -27,7 +27,7 @@ export const postVideo = async (req, res, next) => {
     if (!isValidVideoData(title, description, hashtags, file)) {
       throw new ValidationError("유효하지 않는 video 데이터입니다.", "upload");
     }
-    await VideoService.uploadVideo({
+    await VideoService.uploadVideo(_id, {
       title,
       description,
       hashtags,

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -9,6 +9,7 @@ const userSchema = new mongoose.Schema({
   password: { type: String, required: false, trim: true },
   name: { type: String, required: true, default: "홍길동", trim: true },
   location: { type: String, required: true, default: "지구", trim: true },
+  videos: [{ type: mongoose.Schema.Types.ObjectId, ref: "Video" }],
 });
 
 userSchema.methods.toSafeObject = function () {
@@ -31,7 +32,9 @@ userSchema.pre("validate", function (next) {
 });
 
 userSchema.pre("save", async function () {
-  this.password = await bcrypt.hash(this.password, 5);
+  if (this.isModified("password")) {
+    this.password = await bcrypt.hash(this.password, 5);
+  }
 });
 
 const User = mongoose.model("User", userSchema);

--- a/src/models/Video.js
+++ b/src/models/Video.js
@@ -16,6 +16,7 @@ const videoSchema = new mongoose.Schema({
     views: { type: Number, default: 0 },
     likes: { type: Number, default: 0 },
   },
+  owner: { type: mongoose.Schema.Types.ObjectId, required: true, ref: "User" },
 });
 
 videoSchema.static("parseHashtags", function (hashtags) {

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -26,8 +26,8 @@ export const registerUser = (userDetails, socialOnly = false) => {
   return User.create(data);
 };
 
-export const existsUser = (condition, toBoolean = false) => {
-  const query = User.exists(condition);
+export const existsUser = (filter, toBoolean = true, options) => {
+  const query = User.exists(filter, options);
   return toBoolean ? query.then((user) => Boolean(user)) : query;
 };
 

--- a/src/services/videoService.js
+++ b/src/services/videoService.js
@@ -20,8 +20,8 @@ export const getVideoById = (videoId) => {
   return Video.findById(videoId);
 };
 
-export const existsVideo = (condition, toBoolean = false) => {
-  const query = Video.exists(condition);
+export const existsVideo = (filter, toBoolean = true, options) => {
+  const query = Video.exists(filter, options);
   return toBoolean ? query.then((video) => Boolean(video)) : query;
 };
 

--- a/src/services/videoService.js
+++ b/src/services/videoService.js
@@ -1,3 +1,4 @@
+import { UserService } from ".";
 import Video from "../models/Video";
 import { makeVideoData } from "../utils/dataHandler";
 
@@ -5,15 +6,14 @@ export const findAll = () => {
   return Video.find({}).sort({ createdAt: "desc" });
 };
 
-export const findAllByOwner = (ownerId) => {
-  return Video.find({ owner: ownerId });
-};
-
 export const getPopularVideos = () => {};
 
-export const uploadVideo = (fields) => {
+export const uploadVideo = async (ownerId, fields) => {
   const data = makeVideoData(fields);
-  return Video.create(data);
+  const newVideo = await Video.create(data);
+  const user = await UserService.getUserById(ownerId);
+  user.videos.push(newVideo._id);
+  await user.save();
 };
 
 export const getVideoById = (videoId) => {

--- a/src/services/videoService.js
+++ b/src/services/videoService.js
@@ -5,6 +5,10 @@ export const findAll = () => {
   return Video.find({}).sort({ createdAt: "desc" });
 };
 
+export const findAllByOwner = (ownerId) => {
+  return Video.find({ owner: ownerId });
+};
+
 export const getPopularVideos = () => {};
 
 export const uploadVideo = (fields) => {
@@ -21,9 +25,8 @@ export const existsVideo = (condition, toBoolean = false) => {
   return toBoolean ? query.then((video) => Boolean(video)) : query;
 };
 
-export const updateVideo = (videoId, { file, ...fields }) => {
-  const fileUrl = file?.path;
-  const data = makeVideoData({ ...fields, fileUrl });
+export const updateVideo = (videoId, fields) => {
+  const data = makeVideoData(fields);
   return Video.findByIdAndUpdate(videoId, data);
 };
 

--- a/src/utils/dataHandler.js
+++ b/src/utils/dataHandler.js
@@ -1,6 +1,7 @@
 import Video from "../models/Video";
 
-export const makeVideoData = ({ hashtags, fileUrl, ...fields }) => {
+export const makeVideoData = ({ hashtags, file, ...fields }) => {
+  const fileUrl = file?.path || fields.fileUrl;
   return {
     ...fields,
     fileUrl,

--- a/src/views/profile.pug
+++ b/src/views/profile.pug
@@ -2,7 +2,7 @@ extends base
 include mixins/video
 
 block content
-    each video in videos
+    each video in user.videos
         +video(video)
     else 
         li Sorry nothing found.

--- a/src/views/profile.pug
+++ b/src/views/profile.pug
@@ -1,4 +1,8 @@
 extends base
+include mixins/video
 
 block content
-    h1 유저 프로필
+    each video in videos
+        +video(video)
+    else 
+        li Sorry nothing found.

--- a/src/views/watch.pug
+++ b/src/views/watch.pug
@@ -2,6 +2,7 @@ extends base
 
 block content
     video(src="/"+video.fileUrl, controls)
+    a(href=`/users/${video.owner._id}`)=video.owner.name
     div 
         span 조회수 #{video.meta.views}회
         span #{video.createdAt} 전
@@ -9,8 +10,9 @@ block content
             each hashtag in video.hashtags
                 li=hashtag
     p=video.description
-    a(href=`/videos/${video.id}/edit`) Edit Video &rarr;
-    br
-    form(action=`/videos/${video.id}?_method=DELETE`, method="POST")
-        input(type="hidden" name="_method" value="DELETE")
-        button(type="submit") Delete
+    if String(video.owner._id) === String(loggedInUser._id)
+        a(href=`/videos/${video.id}/edit`) Edit Video &rarr;
+        br
+        form(action=`/videos/${video.id}?_method=DELETE`, method="POST")
+            input(type="hidden" name="_method" value="DELETE")
+            button(type="submit") Delete


### PR DESCRIPTION
### **Refs**

Close #18       

### **Changes:**

- User - Video model 1: N 관계 형성
- 비디오 및 유저 컨트롤러에 populate 및 403 에러 핸들링

### **Notice!**
- Model.exists 6.x 이전 버전과 호환성을 위해 커스텀해서 구현했습니다.

> Model.findById()는 반환할때 전체의 필드를 가져오는 문서이기 때문에 코드상에서 불필요한 필드를 가져오는 경우가 생겼습니다.
findOne() 방식은 `findOne().select().len()` 이러한 형식이므로 코드가 너무 길어지고 문서의 존재 여부와 필드 1개 만 가져오는 방식에는 부합하지 않았습니다. 그래서 다음과 같이 커스텀 하였습니다.
```js
export const existsVideo = (filter, toBoolean = true, options) => {
  const query = Video.exists(filter, options);
  return toBoolean ? query.then((video) => Boolean(video)) : query;
};
```
```js
// videoController.js
// 6.x 이후 버전 처럼 반환값이 id 필드 한개 || null
const video = await VideoService.existsVideo({ _id: id }, false, {
      lean: true,
      select: "owner",
}); 
/*
{
  _id: new ObjectId("64aa8df9709e232a14088e7e"),
  owner: new ObjectId("64aa8d56ad743c1a6a495290")
}
*/
// 5.x 버전 처럼 문서가 존재하는지 여부만 묻고 싶은 경우
const video = await VideoService.existsVideo({ _id: id}); /* true or false */
```